### PR TITLE
Use phive to install tools in CI.

### DIFF
--- a/.github/workflows/cs-stan.yml
+++ b/.github/workflows/cs-stan.yml
@@ -7,6 +7,10 @@ on:
         description: 'Whether to run static analysis for tests'
         required: false
         type: boolean
+      phive_keys:
+        description: 'GPG key signatures for phive packages. Should be comma separated string "800d,d44d"'
+        required: true
+        type: string
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -25,24 +29,42 @@ jobs:
         php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
-        tools: cs2pr, vimeo/psalm:5.6, phpstan:1.9
+        tools: phive, cs2pr
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
+    - name: Get composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Get date part for cache key
+      id: key-date
+      run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
+
+    - name: Cache composer dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
+
     - name: Composer install
-      uses: ramsey/composer-install@v2
+      run: composer update
+
+    - name: Install PHP tools with phive.
+      run: "phive install --trust-gpg-keys '${{ inputs.phive_keys }}'"
 
     - name: Run phpcs
+      if: always()
       run: vendor/bin/phpcs --report=checkstyle src/ tests/ | cs2pr
 
     - name: Run psalm
       if: always()
-      run: psalm --output-format=github
+      run: tools/psalm --output-format=github
 
     - name: Run phpstan
       if: always()
-      run: phpstan analyse --error-format=github
+      run: tools/phpstan analyse --error-format=github
 
     - name: Run phpstan for tests
       if: ${{ inputs.check_tests }}
-      run: phpstan analyse -c tests/phpstan.neon --error-format=github
+      run: tools/phpstan analyse -c tests/phpstan.neon --error-format=github

--- a/.github/workflows/cs-stan.yml
+++ b/.github/workflows/cs-stan.yml
@@ -33,22 +33,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Get composer cache directory
-      id: composer-cache
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-    - name: Get date part for cache key
-      id: key-date
-      run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
-
-    - name: Cache composer dependencies
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
-
     - name: Composer install
-      run: composer update
+      uses: ramsey/composer-install@v2
 
     - name: Install PHP tools with phive.
       run: "phive install --trust-gpg-keys '${{ inputs.phive_keys }}'"


### PR DESCRIPTION
Having to provide the gpgkeys is a bit tedious but I've not found a better way to handle this yet. Adding a required parameter also means this is a breaking change for the CI configuration.