### PR TITLE
PHP 8.3 stable

### DIFF
--- a/.github/workflows/testsuite-with-db.yml
+++ b/.github/workflows/testsuite-with-db.yml
@@ -28,8 +28,7 @@ jobs:
           - php-version: '8.3'
             db-type: sqlite
             dependencies: highest
-            composer-options: "--ignore-platform-reqs"
-            unstable: true
+            unstable: false
 
     services:
       postgres:

--- a/.github/workflows/testsuite-without-db.yml
+++ b/.github/workflows/testsuite-without-db.yml
@@ -25,8 +25,7 @@ jobs:
             unstable: false
           - php-version: '8.3'
             dependencies: highest
-            composer-options: "--ignore-platform-reqs"
-            unstable: true
+            unstable: false
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Should we keep the `composer-options: "--ignore-platform-reqs"`?