### PR TITLE
Don't ignore platform requirements for PHP version.

### DIFF
--- a/.github/workflows/testsuite-with-db.yml
+++ b/.github/workflows/testsuite-with-db.yml
@@ -32,8 +32,7 @@ jobs:
           - php-version: '8.4'
             db-type: mysql
             dependencies: highest
-            unstable: true
-            composer-options: '--ignore-platform-req=php'
+            unstable: false
 
     services:
       postgres:

--- a/.github/workflows/testsuite-without-db.yml
+++ b/.github/workflows/testsuite-without-db.yml
@@ -22,8 +22,7 @@ jobs:
             unstable: false
           - php-version: '8.4'
             dependencies: highest
-            unstable: true
-            composer-options: '--ignore-platform-req=php'
+            unstable: false
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
All our dependencies should be PHP 8.4 compatible now.