### PR TITLE
adjust ci

### DIFF
--- a/.github/workflows/cs-stan.yml
+++ b/.github/workflows/cs-stan.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/testsuite-with-db.yml
+++ b/.github/workflows/testsuite-with-db.yml
@@ -44,6 +44,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup Service
       if: matrix.db-type == 'mysql'

--- a/.github/workflows/testsuite-without-db.yml
+++ b/.github/workflows/testsuite-without-db.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2


### PR DESCRIPTION
I ran https://github.com/woodruffw/zizmor on the current CI config and got the following output:
```
🌈 completed cs-stan.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/kevin/Documents/CakePHP/Org/github/.github/workflows/cs-stan.yml:25:7
   |
25 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> /Users/kevin/Documents/CakePHP/Org/github/.github/workflows/cs-stan.yml:40:7
   |
40 |     - name: Install PHP tools with phive.
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
41 |       run: "phive install --trust-gpg-keys '${{ inputs.phive_keys }}'"
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inputs.phive_keys may expand into attacker-controllable code
   |
   = note: audit confidence → Low

5 findings (3 suppressed): 0 unknown, 0 informational, 0 low, 1 medium, 1 high

🌈 completed testsuite-with-db.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/kevin/Documents/CakePHP/Org/github/.github/workflows/testsuite-with-db.yml:46:7
   |
46 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

5 findings (4 suppressed): 0 unknown, 0 informational, 0 low, 1 medium, 0 high

🌈 completed testsuite-without-db.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/kevin/Documents/CakePHP/Org/github/.github/workflows/testsuite-without-db.yml:28:7
   |
28 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

5 findings (4 suppressed): 0 unknown, 0 informational, 0 low, 1 medium, 0 high
```