### PR TITLE
Introduce reusable docs workflow

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -1,0 +1,244 @@
+name: Reusable Documentation Validation
+
+on:
+  workflow_call:
+    inputs:
+      docs-path:
+        description: 'Path to the docs directory (e.g. "docs")'
+        required: false
+        type: string
+        default: 'docs'
+      enable-toc-check:
+        description: 'Enable TOC link validation (requires .vitepress/toc_*.json)'
+        required: false
+        type: boolean
+        default: false
+      enable-config-js-check:
+        description: 'Enable .vitepress/config.js syntax check'
+        required: false
+        type: boolean
+        default: false
+      enable-json-lint:
+        description: 'Enable TOC JSON file validation'
+        required: false
+        type: boolean
+        default: false
+      enable-spell-check:
+        description: 'Enable spell checking'
+        required: false
+        type: boolean
+        default: true
+      enable-markdown-lint:
+        description: 'Enable markdown linting'
+        required: false
+        type: boolean
+        default: true
+      enable-link-check:
+        description: 'Enable internal link checking'
+        required: false
+        type: boolean
+        default: true
+      cspell-config:
+        description: 'Path to cspell config file (relative to caller repo). Leave empty to use shared default.'
+        required: false
+        type: string
+        default: ''
+      markdownlint-config:
+        description: 'Path to markdownlint config file (relative to caller repo). Leave empty to use shared default.'
+        required: false
+        type: string
+        default: ''
+      linkchecker-baseline:
+        description: 'Path to link checker baseline JSON (relative to caller repo). Leave empty for no baseline.'
+        required: false
+        type: string
+        default: ''
+      tools-ref:
+        description: 'Branch/tag of cakephp/.github to use for shared validation tools and default configs'
+        required: false
+        type: string
+        default: 'main'
+
+jobs:
+  js-lint:
+    name: Validate config.js
+    runs-on: ubuntu-latest
+    if: ${{ inputs.enable-config-js-check }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Validate config.js syntax
+        run: node --check .vitepress/config.js
+
+  json-lint:
+    name: Validate JSON Files
+    runs-on: ubuntu-latest
+    if: ${{ inputs.enable-json-lint }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Validate JSON syntax
+        run: |
+          shopt -s nullglob
+          files=(.vitepress/toc_*.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No .vitepress/toc_*.json files found"
+            exit 1
+          fi
+          for file in "${files[@]}"; do
+            if ! jq empty "$file" 2>/dev/null; then
+              echo "Invalid JSON: $file"
+              exit 1
+            fi
+            echo "Valid: $file"
+          done
+
+  toc-link-check:
+    name: Validate TOC Links
+    runs-on: ubuntu-latest
+    if: ${{ inputs.enable-toc-check }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Checkout shared validation tools
+        uses: actions/checkout@v6
+        with:
+          repository: cakephp/.github
+          ref: ${{ inputs.tools-ref }}
+          path: .docs-tools
+          sparse-checkout: |
+            docs-validation/check-toc-links.cjs
+
+      - name: Check TOC links exist
+        run: node .docs-tools/docs-validation/check-toc-links.cjs
+
+  markdown-lint:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    if: ${{ inputs.enable-markdown-lint }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Checkout shared validation tools
+        uses: actions/checkout@v6
+        with:
+          repository: cakephp/.github
+          ref: ${{ inputs.tools-ref }}
+          path: .docs-tools
+          sparse-checkout: |
+            docs-validation/.markdownlint-cli2.jsonc
+            docs-validation/markdownlint-rules
+
+      - name: Determine config path
+        id: config
+        run: |
+          if [ -n "${{ inputs.markdownlint-config }}" ]; then
+            if [ -f "${{ inputs.markdownlint-config }}" ]; then
+              echo "path=${{ inputs.markdownlint-config }}" >> $GITHUB_OUTPUT
+            else
+              echo "Error: markdownlint config '${{ inputs.markdownlint-config }}' does not exist." >&2
+              exit 1
+            fi
+          else
+            echo "path=.docs-tools/docs-validation/.markdownlint-cli2.jsonc" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Lint markdown files
+        uses: DavidAnson/markdownlint-cli2-action@v23
+        with:
+          config: ${{ steps.config.outputs.path }}
+          globs: '${{ inputs.docs-path }}/**/*.md'
+
+  spell-check:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    if: ${{ inputs.enable-spell-check }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Checkout shared validation tools
+        uses: actions/checkout@v6
+        with:
+          repository: cakephp/.github
+          ref: ${{ inputs.tools-ref }}
+          path: .docs-tools
+          sparse-checkout: |
+            docs-validation/cspell.json
+
+      - name: Determine config path
+        id: config
+        run: |
+          if [ -n "${{ inputs.cspell-config }}" ]; then
+            if [ -f "${{ inputs.cspell-config }}" ]; then
+              echo "path=${{ inputs.cspell-config }}" >> $GITHUB_OUTPUT
+            else
+              echo "Error: cspell config '${{ inputs.cspell-config }}' does not exist." >&2
+              exit 1
+            fi
+          else
+            echo "path=.docs-tools/docs-validation/cspell.json" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check spelling
+        uses: streetsidesoftware/cspell-action@v8
+        with:
+          files: '${{ inputs.docs-path }}/**/*.md'
+          config: ${{ steps.config.outputs.path }}
+          incremental_files_only: true
+
+  link-check:
+    name: Check Internal Links
+    runs-on: ubuntu-latest
+    if: ${{ inputs.enable-link-check }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Checkout shared validation tools
+        uses: actions/checkout@v6
+        with:
+          repository: cakephp/.github
+          ref: ${{ inputs.tools-ref }}
+          path: .docs-tools
+          sparse-checkout: |
+            docs-validation/check-links.cjs
+
+      - name: Get changed markdown files
+        id: changed-files
+        run: |
+          DOCS_PATH="${{ inputs.docs-path }}"
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            if [ -z "$BASE_SHA" ]; then
+              git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
+              BASE_SHA="origin/${{ github.base_ref }}"
+            fi
+            FILES=$(git diff --name-only --diff-filter=d "${BASE_SHA}"...HEAD | grep "^${DOCS_PATH}/.*\.md$" || true)
+            if [ -z "$FILES" ]; then
+              echo "No markdown files changed in ${DOCS_PATH}/"
+              echo "files=" >> $GITHUB_OUTPUT
+            else
+              echo "files=$(echo $FILES | tr '\n' ' ')" >> $GITHUB_OUTPUT
+              echo "Checking files:"
+              echo "$FILES"
+            fi
+          else
+            echo "files=${DOCS_PATH}/**/*.md" >> $GITHUB_OUTPUT
+            echo "Checking all files: ${DOCS_PATH}/**/*.md"
+          fi
+
+      - name: Check internal links
+        if: steps.changed-files.outputs.files != ''
+        run: |
+          BASELINE_ARG=""
+          if [ -n "${{ inputs.linkchecker-baseline }}" ] && [ -f "${{ inputs.linkchecker-baseline }}" ]; then
+            BASELINE_ARG="--baseline ${{ inputs.linkchecker-baseline }}"
+          fi
+          node .docs-tools/docs-validation/check-links.cjs $BASELINE_ARG ${{ steps.changed-files.outputs.files }}

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: 'docs'
+      vitepress-path:
+        description: 'Path to the .vitepress directory (e.g. ".vitepress" or "docs/.vitepress")'
+        required: false
+        type: string
+        default: '.vitepress'
       enable-toc-check:
         description: 'Enable TOC link validation (requires .vitepress/toc_*.json)'
         required: false
@@ -69,7 +74,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Validate config.js syntax
-        run: node --check .vitepress/config.js
+        run: node --check "${{ inputs.vitepress-path }}/config.js"
 
   json-lint:
     name: Validate JSON Files
@@ -82,9 +87,9 @@ jobs:
       - name: Validate JSON syntax
         run: |
           shopt -s nullglob
-          files=(.vitepress/toc_*.json)
+          files=("${{ inputs.vitepress-path }}"/toc_*.json)
           if [ ${#files[@]} -eq 0 ]; then
-            echo "No .vitepress/toc_*.json files found"
+            echo "No ${{ inputs.vitepress-path }}/toc_*.json files found"
             exit 1
           fi
           for file in "${files[@]}"; do
@@ -113,7 +118,7 @@ jobs:
             docs-validation/check-toc-links.cjs
 
       - name: Check TOC links exist
-        run: node .docs-tools/docs-validation/check-toc-links.cjs
+        run: node .docs-tools/docs-validation/check-toc-links.cjs --vitepress-path "${{ inputs.vitepress-path }}" --docs-path "${{ inputs.docs-path }}"
 
   markdown-lint:
     name: Lint Markdown

--- a/docs-validation/.markdownlint-cli2.jsonc
+++ b/docs-validation/.markdownlint-cli2.jsonc
@@ -1,0 +1,83 @@
+{
+  "config": {
+    "default": true,
+    "heading-increment": true,
+    "no-hard-tabs": true,
+    "no-multiple-blanks": true,
+    "line-length": false,
+    "commands-show-output": true,
+    "blanks-around-headings": true,
+    "heading-start-left": true,
+    "no-duplicate-heading": false,
+    "single-h1": false,
+    "no-trailing-punctuation": false,
+    "no-blanks-blockquote": false,
+    "list-marker-space": true,
+    "blanks-around-fences": true,
+    "blanks-around-lists": true,
+    "no-inline-html": {
+      "allowed_elements": [
+        "Badge",
+        "div",
+        "span",
+        "br",
+        "style",
+        "details",
+        "summary",
+        "table",
+        "thead",
+        "tbody",
+        "tr",
+        "th",
+        "td",
+        "img",
+        "a",
+        "svg",
+        "path",
+        "figure",
+        "p",
+        "colgroup",
+        "col",
+        "strong",
+        "sup",
+        "section",
+        "hr",
+        "ol",
+        "ul",
+        "li",
+        "em",
+        "code"
+      ]
+    },
+    "no-bare-urls": true,
+    "fenced-code-language": true,
+    "first-line-heading": false,
+    "code-block-style": false,
+    "code-fence-style": {
+      "style": "backtick"
+    },
+    "emphasis-style": {
+      "style": "asterisk"
+    },
+    "strong-style": {
+      "style": "asterisk"
+    },
+    "spaces-after-emphasis-marker": true,
+    "spaces-after-code-fence-info": true,
+    "spaces-inside-emphasis-markers": true,
+    "spaces-inside-code-span-elements": true,
+    "single-trailing-newline": true,
+    "link-fragments": false,
+    "table-pipe-style": "leading_and_trailing",
+    "table-column-count": false,
+    "table-column-style": false,
+    "descriptive-link-text": false,
+    "no-emphasis-as-heading": false
+  },
+  "customRules": [
+    "./markdownlint-rules/no-space-after-fence.cjs"
+  ],
+  "ignores": [
+    "node_modules/**"
+  ]
+}

--- a/docs-validation/check-links.cjs
+++ b/docs-validation/check-links.cjs
@@ -75,9 +75,7 @@ function matchPattern(filename, pattern) {
     .replace(/\./g, "\\.")
     .replace(/\*/g, ".*")
     .replace(/\?/g, ".");
-  return (
-    new RegExp(`^${regex}$`).test(filename) || new RegExp(regex).test(filename)
-  );
+  return new RegExp(`^${regex}$`).test(filename);
 }
 
 class LinkChecker {
@@ -201,7 +199,7 @@ class LinkChecker {
         continue;
       }
 
-      const { targetPath, anchor } = this.parseLink(link.url, sourceDir);
+      const { targetPath, anchor } = this.parseLink(link.url, sourceDir, filePath);
 
       // Check file exists
       if (!fs.existsSync(targetPath)) {
@@ -269,20 +267,20 @@ class LinkChecker {
    * Check if a URL is external
    */
   isExternalLink(url) {
-    // Skip HTTP(S), mailto, IRC, anchor-only, protocol-relative, and absolute paths (VitePress public dir)
-    return /^(https?:\/\/|mailto:|irc:\/\/|#|\/\/|\/[^.])/i.test(url);
+    // Skip HTTP(S), mailto, IRC, protocol-relative, and absolute paths (VitePress public dir)
+    return /^(https?:\/\/|mailto:|irc:\/\/|\/\/|\/[^.])/i.test(url);
   }
 
   /**
    * Parse link URL into target path and anchor
    */
-  parseLink(url, sourceDir) {
+  parseLink(url, sourceDir, sourceFile) {
     const [pathPart, anchor] = url.split("#");
 
     // Handle anchor-only links (same file)
     if (!pathPart) {
       return {
-        targetPath: path.join(sourceDir, path.basename(sourceDir) + ".md"),
+        targetPath: sourceFile,
         anchor,
       };
     }

--- a/docs-validation/check-links.cjs
+++ b/docs-validation/check-links.cjs
@@ -1,0 +1,497 @@
+#!/usr/bin/env node
+
+/**
+ * Internal Markdown Link Checker
+ *
+ * Validates internal markdown links in documentation files.
+ * Only checks relative links - ignores external URLs.
+ *
+ * Usage:
+ *   node bin/check-links.js <file-or-pattern>...
+ *   node bin/check-links.js --baseline <path> "docs/subfolder/*.md"
+ *   node bin/check-links.js --generate-baseline "docs/subfolder/*.md"
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const BASELINE_FILE = ".github/linkchecker-baseline.json";
+
+/**
+ * Simple glob implementation using Node.js built-ins
+ */
+function globSync(pattern, options = {}) {
+  const results = [];
+
+  // Handle simple patterns like "docs/en/**/*.md"
+  if (pattern.includes("**")) {
+    const [basePath, ...rest] = pattern.split("**");
+    const suffix = rest.join("**").replace(/^\//, ""); // Remove leading slash
+    const baseDir = basePath.replace(/\/$/, "") || ".";
+
+    function traverse(dir) {
+      try {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+        for (const entry of entries) {
+          const fullPath = path.join(dir, entry.name);
+
+          if (entry.isDirectory()) {
+            traverse(fullPath);
+          } else if (entry.isFile() && matchPattern(entry.name, suffix)) {
+            results.push(options.absolute ? path.resolve(fullPath) : fullPath);
+          }
+        }
+      } catch (err) {
+        // Ignore permission errors
+      }
+    }
+
+    traverse(baseDir);
+  } else {
+    // Simple wildcard pattern like "docs/en/*.md"
+    const dir = path.dirname(pattern);
+    const filePattern = path.basename(pattern);
+
+    if (fs.existsSync(dir)) {
+      const entries = fs.readdirSync(dir);
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry);
+        if (
+          fs.statSync(fullPath).isFile() &&
+          matchPattern(entry, filePattern)
+        ) {
+          results.push(options.absolute ? path.resolve(fullPath) : fullPath);
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+function matchPattern(filename, pattern) {
+  const regex = pattern
+    .replace(/\./g, "\\.")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return (
+    new RegExp(`^${regex}$`).test(filename) || new RegExp(regex).test(filename)
+  );
+}
+
+class LinkChecker {
+  constructor(options = {}) {
+    this.errors = [];
+    this.checked = new Set();
+    this.headingCache = new Map();
+    this.generateBaseline = options.generateBaseline || false;
+    this.baselinePath = options.baselinePath || null;
+    this.baseline = this.baselinePath ? this.loadBaseline() : [];
+  }
+
+  /**
+   * Load baseline configuration
+   */
+  loadBaseline() {
+    if (!fs.existsSync(this.baselinePath)) {
+      console.warn(`Warning: Baseline file not found: ${this.baselinePath}`);
+      return [];
+    }
+
+    try {
+      const content = fs.readFileSync(this.baselinePath, "utf8");
+      return JSON.parse(content);
+    } catch (err) {
+      console.warn(`Warning: Could not load baseline file: ${err.message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Save baseline configuration
+   */
+  saveBaseline() {
+    const baselineData = this.errors.map((error) => ({
+      file: error.file,
+      link: error.link,
+      message: error.message,
+    }));
+
+    const outputPath = this.baselinePath || BASELINE_FILE;
+    const dir = path.dirname(outputPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    fs.writeFileSync(
+      outputPath,
+      JSON.stringify(baselineData, null, 2) + "\n",
+      "utf8",
+    );
+  }
+
+  /**
+   * Check if an error matches baseline
+   */
+  isInBaseline(error) {
+    return this.baseline.some(
+      (baselineError) =>
+        baselineError.file === error.file && baselineError.link === error.link,
+    );
+  }
+
+  /**
+   * Main entry point - check files matching patterns
+   */
+  async checkFiles(patterns) {
+    const files = await this.resolveFiles(patterns);
+
+    if (files.length === 0) {
+      console.error("No files found matching patterns");
+      return false;
+    }
+
+    console.log(`Checking ${files.length} file(s)...\n`);
+
+    for (const file of files) {
+      this.checkFile(file);
+    }
+
+    return this.reportResults();
+  }
+
+  /**
+   * Resolve glob patterns to actual file paths
+   */
+  async resolveFiles(patterns) {
+    const fileSet = new Set();
+
+    for (const pattern of patterns) {
+      // Check if it's a direct file path
+      if (fs.existsSync(pattern) && fs.statSync(pattern).isFile()) {
+        fileSet.add(path.resolve(pattern));
+      } else {
+        // Treat as glob pattern
+        const matches = globSync(pattern, {
+          absolute: true,
+        });
+        matches.forEach((f) => fileSet.add(f));
+      }
+    }
+
+    return Array.from(fileSet).sort();
+  }
+
+  /**
+   * Check all links in a single file
+   */
+  checkFile(filePath) {
+    if (this.checked.has(filePath)) {
+      return;
+    }
+    this.checked.add(filePath);
+
+    const content = fs.readFileSync(filePath, "utf8");
+    const links = this.extractLinks(content);
+    const sourceDir = path.dirname(filePath);
+
+    for (const link of links) {
+      if (this.isExternalLink(link.url)) {
+        continue;
+      }
+
+      const { targetPath, anchor } = this.parseLink(link.url, sourceDir);
+
+      // Check file exists
+      if (!fs.existsSync(targetPath)) {
+        this.addError(
+          filePath,
+          link,
+          `File not found: ${path.relative(process.cwd(), targetPath)}`,
+        );
+        continue;
+      }
+
+      // Check anchor if present
+      if (anchor) {
+        const headings = this.getHeadings(targetPath);
+        const anchorId = this.slugify(anchor);
+
+        if (!headings.includes(anchorId)) {
+          this.addError(
+            filePath,
+            link,
+            `Anchor '#${anchor}' not found in ${path.relative(process.cwd(), targetPath)}`,
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Extract all markdown links from content
+   */
+  extractLinks(content) {
+    const links = [];
+
+    // Remove code blocks first (fenced with ```), then inline code (single backticks)
+    let contentWithoutCodeBlocks = content.replace(/```[\s\S]*?```/g, "");
+    // For inline code, only match within a single line (no newlines)
+    contentWithoutCodeBlocks = contentWithoutCodeBlocks.replace(
+      /`[^`\n]+`/g,
+      "",
+    );
+
+    // Match [text](url) or [text](url "title")
+    const linkRegex = /\[([^\]]+)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+    let match;
+
+    while ((match = linkRegex.exec(contentWithoutCodeBlocks)) !== null) {
+      const url = match[2];
+
+      // Skip bare URLs wrapped in angle brackets (e.g., <https://example.com>)
+      if (url.startsWith("<") && url.endsWith(">")) {
+        continue;
+      }
+
+      links.push({
+        text: match[1],
+        url: url,
+        raw: match[0],
+      });
+    }
+
+    return links;
+  }
+
+  /**
+   * Check if a URL is external
+   */
+  isExternalLink(url) {
+    // Skip HTTP(S), mailto, IRC, anchor-only, protocol-relative, and absolute paths (VitePress public dir)
+    return /^(https?:\/\/|mailto:|irc:\/\/|#|\/\/|\/[^.])/i.test(url);
+  }
+
+  /**
+   * Parse link URL into target path and anchor
+   */
+  parseLink(url, sourceDir) {
+    const [pathPart, anchor] = url.split("#");
+
+    // Handle anchor-only links (same file)
+    if (!pathPart) {
+      return {
+        targetPath: path.join(sourceDir, path.basename(sourceDir) + ".md"),
+        anchor,
+      };
+    }
+
+    let targetPath = path.resolve(sourceDir, pathPart);
+
+    // VitePress automatically adds .md extension if not present
+    // Match this behavior by always trying .md first for extensionless links
+    if (!path.extname(targetPath)) {
+      const mdPath = targetPath + ".md";
+      if (fs.existsSync(mdPath)) {
+        targetPath = mdPath;
+      } else if (
+        fs.existsSync(targetPath) &&
+        fs.statSync(targetPath).isDirectory()
+      ) {
+        // If it's a directory, look for index.md
+        targetPath = path.join(targetPath, "index.md");
+      } else {
+        // Default to .md extension (VitePress behavior)
+        targetPath = mdPath;
+      }
+    } else if (
+      fs.existsSync(targetPath) &&
+      fs.statSync(targetPath).isDirectory()
+    ) {
+      // If path is directory, look for index.md
+      targetPath = path.join(targetPath, "index.md");
+    }
+
+    return { targetPath, anchor };
+  }
+
+  /**
+   * Extract headings from a markdown file
+   */
+  getHeadings(filePath) {
+    if (this.headingCache.has(filePath)) {
+      return this.headingCache.get(filePath);
+    }
+
+    const content = fs.readFileSync(filePath, "utf8");
+    const headings = [];
+
+    // Match ATX headings: # Heading
+    const headingRegex = /^#{1,6}\s+(.+)$/gm;
+    let match;
+
+    while ((match = headingRegex.exec(content)) !== null) {
+      const heading = match[1]
+        .replace(/\{#([^}]+)\}$/g, "") // Remove {#custom-id} but keep the ID
+        .replace(/\[[^\]]+\]\([^)]+\)/g, "") // Remove links
+        .replace(/`([^`]+)`/g, "$1") // Remove code formatting
+        .trim();
+
+      // Check if there's a custom ID in the original match
+      const customIdMatch = match[1].match(/\{#([^}]+)\}$/);
+      if (customIdMatch) {
+        headings.push(customIdMatch[1]); // Add the custom ID
+      }
+
+      headings.push(this.slugify(heading));
+    }
+
+    // Also extract HTML anchor IDs: <a id="anchor-name"></a>
+    const htmlAnchorRegex = /<a\s+id=["']([^"']+)["']/gi;
+    while ((match = htmlAnchorRegex.exec(content)) !== null) {
+      headings.push(match[1]);
+    }
+
+    this.headingCache.set(filePath, headings);
+    return headings;
+  }
+
+  /**
+   * Convert heading text to anchor ID (VitePress style)
+   */
+  slugify(text) {
+    return text
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\s-]/g, "") // Remove special chars
+      .replace(/\s+/g, "-") // Spaces to hyphens
+      .replace(/-+/g, "-") // Multiple hyphens to single
+      .replace(/^-|-$/g, ""); // Trim hyphens
+  }
+
+  /**
+   * Add an error to the collection
+   */
+  addError(filePath, link, message) {
+    this.errors.push({
+      file: path.relative(process.cwd(), filePath),
+      link: link.url,
+      text: link.text,
+      message,
+    });
+  }
+
+  /**
+   * Report results and return success status
+   */
+  reportResults() {
+    if (this.generateBaseline) {
+      this.saveBaseline();
+      const outputPath = this.baselinePath || BASELINE_FILE;
+      console.log(
+        `✓ Baseline generated with ${this.errors.length} known issue(s)`,
+      );
+      console.log(`  Saved to: ${outputPath}\n`);
+      return true;
+    }
+
+    // Filter out baseline errors
+    const newErrors = this.errors.filter((error) => !this.isInBaseline(error));
+
+    if (newErrors.length === 0 && this.errors.length === 0) {
+      console.log("✓ All internal links are valid!\n");
+      return true;
+    }
+
+    if (newErrors.length === 0 && this.errors.length > 0) {
+      console.log(
+        `✓ No new broken links (${this.errors.length} known issue(s) in baseline)\n`,
+      );
+      return true;
+    }
+
+    console.error(`✗ Found ${newErrors.length} new broken link(s):\n`);
+
+    for (const error of newErrors) {
+      console.error(`  ${error.file}`);
+      console.error(`    Link: [${error.text}](${error.link})`);
+      console.error(`    Error: ${error.message}`);
+      console.error("");
+    }
+
+    if (this.errors.length > newErrors.length) {
+      const baselineCount = this.errors.length - newErrors.length;
+      console.error(
+        `  (${baselineCount} known issue(s) ignored from baseline)\n`,
+      );
+    }
+
+    return false;
+  }
+}
+
+// Main execution
+async function main() {
+  const args = process.argv.slice(2);
+
+  // Parse arguments
+  let generateBaseline = false;
+  let baselinePath = null;
+  const patterns = [];
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--generate-baseline") {
+      generateBaseline = true;
+    } else if (args[i] === "--baseline") {
+      if (i + 1 < args.length) {
+        baselinePath = args[++i];
+      } else {
+        console.error("Error: --baseline requires a path argument");
+        process.exit(1);
+      }
+    } else {
+      patterns.push(args[i]);
+    }
+  }
+
+  if (patterns.length === 0) {
+    console.error(
+      "Usage: node bin/check-links.js [--baseline <path>] [--generate-baseline] <file-or-pattern>...",
+    );
+    console.error("");
+    console.error("Examples:");
+    console.error("  node bin/check-links.js docs/en/installation.md");
+    console.error('  node bin/check-links.js "docs/**/*.md"');
+    console.error("  node bin/check-links.js docs/en/*.md docs/ja/*.md");
+    console.error("");
+    console.error("With baseline:");
+    console.error(
+      '  node bin/check-links.js --baseline .github/linkchecker-baseline.json "docs/**/*.md"',
+    );
+    console.error("");
+    console.error("Generate baseline:");
+    console.error(
+      '  node bin/check-links.js --generate-baseline "docs/**/*.md"',
+    );
+    console.error(
+      '  node bin/check-links.js --generate-baseline --baseline custom-baseline.json "docs/**/*.md"',
+    );
+    process.exit(1);
+  }
+
+  const checker = new LinkChecker({ generateBaseline, baselinePath });
+  const success = await checker.checkFiles(patterns);
+
+  process.exit(success ? 0 : 1);
+}
+
+// Run if executed directly
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("Error:", error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = LinkChecker;

--- a/docs-validation/check-toc-links.cjs
+++ b/docs-validation/check-toc-links.cjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+/**
+ * TOC Link Validator
+ *
+ * Validates that all links in toc_*.json files point to existing markdown files.
+ *
+ * Usage:
+ *   node bin/check-toc-links.js
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Recursively extract all links from TOC items
+ */
+function extractLinks(items, links = []) {
+  for (const item of items) {
+    if (item.link && !item.link.startsWith("http")) {
+      links.push(item.link);
+    }
+    if (item.items) {
+      extractLinks(item.items, links);
+    }
+  }
+  return links;
+}
+
+/**
+ * Check if a TOC link resolves to an existing file
+ */
+function checkLink(link, docsDir, lang) {
+  // TOC links may include language prefix: "/ja/quickstart" or just "/quickstart"
+  // Strip the language prefix if present
+  let relativePath = link.startsWith("/") ? link.slice(1) : link;
+
+  // Remove language prefix if link starts with it (e.g., "ja/quickstart" -> "quickstart")
+  const langPrefix = lang + "/";
+  if (relativePath.startsWith(langPrefix)) {
+    relativePath = relativePath.slice(langPrefix.length);
+  }
+
+  const filePath = path.join(docsDir, relativePath + ".md");
+
+  return fs.existsSync(filePath);
+}
+
+/**
+ * Extract language code from TOC filename
+ * e.g., "toc_en.json" -> "en"
+ */
+function getLangFromTocFile(tocFile) {
+  const match = tocFile.match(/toc_(\w+)\.json$/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Main validation function
+ */
+function validateTocFiles() {
+  const tocFiles = fs.readdirSync(".vitepress").filter((f) => f.match(/^toc_.*\.json$/)).map((f) => `.vitepress/${f}`);
+
+  if (tocFiles.length === 0) {
+    console.error("No toc_*.json files found");
+    process.exit(1);
+  }
+
+  let hasErrors = false;
+
+  for (const tocFile of tocFiles) {
+    const lang = getLangFromTocFile(tocFile);
+    if (!lang) {
+      console.error(`Could not extract language from ${tocFile}`);
+      continue;
+    }
+
+    const docsDir = path.join("docs", lang);
+    if (!fs.existsSync(docsDir)) {
+      console.error(`Docs directory not found: ${docsDir}`);
+      hasErrors = true;
+      continue;
+    }
+
+    console.log(`Checking ${tocFile} against ${docsDir}/...`);
+
+    const content = fs.readFileSync(tocFile, "utf8");
+    const toc = JSON.parse(content);
+
+    // TOC structure has keys like "/" with arrays of items
+    const allLinks = [];
+    for (const key of Object.keys(toc)) {
+      extractLinks(toc[key], allLinks);
+    }
+
+    const missingFiles = [];
+    for (const link of allLinks) {
+      if (!checkLink(link, docsDir, lang)) {
+        missingFiles.push(link);
+      }
+    }
+
+    if (missingFiles.length > 0) {
+      hasErrors = true;
+      console.error(`\n✗ ${tocFile}: ${missingFiles.length} broken link(s)\n`);
+      for (const link of missingFiles) {
+        // Calculate expected path (strip lang prefix if present)
+        let relativePath = link.startsWith("/") ? link.slice(1) : link;
+        const langPrefix = lang + "/";
+        if (relativePath.startsWith(langPrefix)) {
+          relativePath = relativePath.slice(langPrefix.length);
+        }
+        const expectedPath = path.join(docsDir, relativePath + ".md");
+        console.error(`  ${link}`);
+        console.error(`    Expected: ${expectedPath}`);
+      }
+      console.error("");
+    } else {
+      console.log(`✓ ${tocFile}: ${allLinks.length} link(s) valid\n`);
+    }
+  }
+
+  if (hasErrors) {
+    console.error("TOC validation failed");
+    process.exit(1);
+  }
+
+  console.log("✓ All TOC links are valid!");
+}
+
+validateTocFiles();

--- a/docs-validation/check-toc-links.cjs
+++ b/docs-validation/check-toc-links.cjs
@@ -59,7 +59,19 @@ function getLangFromTocFile(tocFile) {
  * Main validation function
  */
 function validateTocFiles() {
-  const tocFiles = fs.readdirSync(".vitepress").filter((f) => f.match(/^toc_.*\.json$/)).map((f) => `.vitepress/${f}`);
+  const args = process.argv.slice(2);
+  let vitepressPath = ".vitepress";
+  let docsBasePath = "docs";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--vitepress-path" && i + 1 < args.length) {
+      vitepressPath = args[++i];
+    } else if (args[i] === "--docs-path" && i + 1 < args.length) {
+      docsBasePath = args[++i];
+    }
+  }
+
+  const tocFiles = fs.readdirSync(vitepressPath).filter((f) => f.match(/^toc_.*\.json$/)).map((f) => path.join(vitepressPath, f));
 
   if (tocFiles.length === 0) {
     console.error("No toc_*.json files found");
@@ -75,7 +87,7 @@ function validateTocFiles() {
       continue;
     }
 
-    const docsDir = path.join("docs", lang);
+    const docsDir = path.join(docsBasePath, lang);
     if (!fs.existsSync(docsDir)) {
       console.error(`Docs directory not found: ${docsDir}`);
       hasErrors = true;

--- a/docs-validation/cspell.json
+++ b/docs-validation/cspell.json
@@ -1,0 +1,112 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "caseSensitive": false,
+  "words": [
+    "CakePHP",
+    "VitePress",
+    "php",
+    "datetime",
+    "varchar",
+    "postgresql",
+    "mysql",
+    "sqlite",
+    "webroot",
+    "csrf",
+    "xss",
+    "cakephp",
+    "bake",
+    "phinx",
+    "hasher",
+    "middlewares",
+    "namespaced",
+    "phpunit",
+    "composable",
+    "autowiring",
+    "stringable",
+    "arrayable",
+    "timestampable",
+    "paginator",
+    "Enqueue",
+    "dequeue",
+    "nullable",
+    "accessor",
+    "mutator",
+    "minphpversion",
+    "phpversion",
+    "XAMPP",
+    "WAMP",
+    "MAMP",
+    "controllername",
+    "actionname",
+    "Datamapper",
+    "webservices",
+    "nginx",
+    "apache",
+    "httpd",
+    "lighttpd",
+    "mbstring",
+    "simplexml",
+    "Laragon",
+    "composer",
+    "phar",
+    "paginate",
+    "startup",
+    "endfor",
+    "endwhile",
+    "sidebar",
+    "blocks",
+    "rewrite",
+    "before",
+    "called",
+    "sites",
+    "example",
+    "Classes",
+    "Redirect",
+    "Layout",
+    "full",
+    "olde",
+    "olle"
+  ],
+  "ignoreRegExpList": [
+    "\\$[a-zA-Z_][a-zA-Z0-9_]*",
+    "[a-zA-Z]+::[a-zA-Z]+",
+    "<[^>]+>",
+    "`[^`]+`",
+    "```[\\s\\S]*?```",
+    "\\b[A-Z][a-z]+(?:[A-Z][a-z]+)+\\b",
+    "\\b[a-z]+_[a-z_]+\\b",
+    "\\bhttps?:\\/\\/[^\\s]+",
+    "\\[[a-z]\\][a-z]+",
+    "\\b[A-Z][a-z]+\\b",
+    "\\b(true|false|null|while|for|if|else)\\b"
+  ],
+  "languageSettings": [
+    {
+      "languageId": "*",
+      "locale": "en",
+      "dictionaries": ["en", "softwareTerms", "php"]
+    },
+    {
+      "languageId": "*",
+      "locale": "ja",
+      "allowCompoundWords": true
+    }
+  ],
+  "overrides": [
+    {
+      "filename": "**/docs/ja/**/*.md",
+      "language": "ja",
+      "ignoreRegExpList": [
+        "[\\p{Script=Hiragana}\\p{Script=Katakana}\\p{Script=Han}]+"
+      ]
+    }
+  ],
+  "ignorePaths": [
+    "node_modules/**",
+    ".temp/**",
+    "dist/**",
+    "**/*.min.js",
+    "**/*.lock"
+  ]
+}

--- a/docs-validation/markdownlint-rules/no-space-after-fence.cjs
+++ b/docs-validation/markdownlint-rules/no-space-after-fence.cjs
@@ -1,0 +1,35 @@
+"use strict";
+
+module.exports = {
+  names: ["no-space-after-fence"],
+  description: "Disallow spaces between a fence and the info string.",
+  tags: ["code", "fences", "whitespace"],
+  function: function noSpaceAfterFence(params, onError) {
+    const lines = params.lines || [];
+
+    (params.tokens || []).forEach((token) => {
+      if (token.type !== "fence") {
+        return;
+      }
+
+      if (!token.markup || token.markup[0] !== "`") {
+        return;
+      }
+
+      if (!token.map || token.map.length === 0) {
+        return;
+      }
+
+      const lineNumber = token.map[0] + 1;
+      const line = lines[lineNumber - 1] || "";
+
+      if (/^\s*`{3,}[ \t]+\S/.test(line)) {
+        onError({
+          lineNumber,
+          detail: "Remove the space between the fence and the info string.",
+          context: line.trim()
+        });
+      }
+    });
+  }
+};


### PR DESCRIPTION
This refactors and moves the documentation workflow from the docs repository into a reusable workflow we can adapt for our plugins too.

See cakephp/docs#8268 for a usage example.

Simple workflow usage example:

```yml
jobs:
  validate:
    uses: cakephp/.github/.github/workflows/docs-validation.yml@5.x
    with:
      docs-path: 'docs'
      enable-config-js-check: true
      enable-json-lint: true
      enable-toc-check: true
      enable-spell-check: true
      enable-markdown-lint: true
      enable-link-check: true
      linkchecker-baseline: '.github/linkchecker-baseline.json'
      tools-ref: '5.x'
```