### PR TITLE
Bust rector cache when rector version changes

### DIFF
--- a/.github/workflows/cs-stan.yml
+++ b/.github/workflows/cs-stan.yml
@@ -58,13 +58,22 @@ jobs:
       if: always()
       run: vendor/bin/phpcs --report=checkstyle | cs2pr
 
+    - name: Install rector
+      if: ${{ always() && hashFiles('rector.php') }}
+      run: composer rector-setup
+
+    - name: Get rector version
+      if: ${{ always() && hashFiles('rector.php') }}
+      id: rector-version
+      run: echo "value=$(composer show rector/rector --format=json | jq -r '.versions[0]')" >> "$GITHUB_OUTPUT"
+
     - name: Setup rector cache
       if: ${{ always() && hashFiles('rector.php') }}
       uses: actions/cache@v5
       with:
         path: ${{ runner.temp }}/rector
-        key: ${{ runner.os }}-rector-${{ hashFiles('rector.php', 'composer.lock') }}
-        restore-keys: ${{ runner.os }}-rector-
+        key: ${{ runner.os }}-rector-${{ steps.rector-version.outputs.value }}-${{ hashFiles('rector.php', 'composer.lock') }}
+        restore-keys: ${{ runner.os }}-rector-${{ steps.rector-version.outputs.value }}-
 
     - name: Create rector cache dir
       if: ${{ always() && hashFiles('rector.php') }}
@@ -74,4 +83,4 @@ jobs:
       if: ${{ always() && hashFiles('rector.php') }}
       env:
         RECTOR_CACHE_DIR: ${{ runner.temp }}/rector
-      run: composer rector-setup && composer rector-check
+      run: composer rector-check


### PR DESCRIPTION
## Summary

The rector analysis cache stores per-file 'no-changes-needed' verdicts. Those verdicts depend on which rector rules exist at analysis time, but the current cache key only hashes `rector.php` and `composer.lock` — neither of which change when rector itself releases a new version with new rules.

Concrete impact: in cakephp/migrations#1083 we discovered two pre-existing visibility issues (`MakeInheritedMethodVisibilitySameAsParentRector`) that had been silently passing CI for weeks because the rector cache kept reporting 'no changes' on the same source files even after rector shipped that rule. They only surfaced when an unrelated source change happened to bust the cache.

## Fix

- Run `composer rector-setup` first as a separate step (was previously chained with `rector-check`).
- Read the installed rector version with `composer show rector/rector --format=json | jq -r '.versions[0]'`.
- Include that version in both `key` and `restore-keys` so cache entries from a different rector version are not restored.

Net effect: the cache still accelerates re-runs on the same rector version, but a new rector minor or patch release forces a fresh analysis on the next CI run.

## Notes

- jq is preinstalled on `ubuntu-24.04` runners.
- Splitting `rector-setup` from `rector-check` is required because we need rector installed *before* the cache step in order to read the version. Adds a few seconds to runs that were already a cache hit; rector-setup is light (one composer require), so the overhead is negligible.
